### PR TITLE
Automatically generate active yaml purpose model when creating a new app

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -354,35 +354,26 @@ module Rails
 ---
 # add your purpose tree here
 sales:
-  id: 1
   name: sales
   children:
     calls:
-      id: 3
       name: sales_calls
 marketing:
-  id: 2
   name: marketing
   children:
     external:
-      id: 6
       name: external_marketing
       children:
         email:
-          id: 7
           name: external_marketing_email
           children:
             annoying_emails:
-              id: 8
               name: annoying_external_marketing_emails
             useful_emails:
-              id: 9
               name: useful_external_marketing_emails
     email:
-      id: 4
       name: email
     telephone:
-      id: 5
       name: telephone
             HEREDOC
           )
@@ -395,16 +386,17 @@ def parse(purpose, pid)
   return {} if purpose.nil?
   purposes = {}
 
-  id = purpose['id']
+  node_id = $id
   name = purpose['name']
 
   if purpose['children']
     purpose['children'].each do |_, value|
-      purposes.merge!(parse(value, id))
+      $id += 1
+      purposes.merge!(parse(value, node_id))
     end
   end
 
-  le_hash = { 'id' => id, 'name' => name }
+  le_hash = { 'id' => node_id, 'name' => name }
   le_hash['parent_id'] = pid unless pid.nil?
 
   purposes.merge!(name => le_hash)
@@ -417,7 +409,9 @@ stuff = YAML.load_file('purposes.seed')
 
 purposes = {}
 
+$id = 0
 stuff.each do |key, value|
+  $id += 1
   purposes.merge!(parse(value, nil))
 end
 
@@ -445,7 +439,6 @@ file. If you encounter any errors, your schema is most likely corrupt.
 
 Things to note:
 - every purpose needs the following attributes
-  - id: a counting id (unique!)
   - name: an identifying name (unique!)
   - children: embedded child purposes (optional)
 - node names are ignored, only the name attribute is used

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -405,14 +405,14 @@ def parse(purpose, pid)
 end
 
 require 'yaml'
-stuff = YAML.load_file('purposes.seed')
+tree = YAML.load_file('purposes.seed')
 
 purposes = {}
 
 $id = 0
-stuff.each do |key, value|
+tree.each do |_, node|
   $id += 1
-  purposes.merge!(parse(value, nil))
+  purposes.merge!(parse(node, nil))
 end
 
 purposes = purposes.sort_by { |key, value| value['id'] }.to_h
@@ -439,7 +439,7 @@ file. If you encounter any errors, your schema is most likely corrupt.
 
 Things to note:
 - every purpose needs the following attributes
-  - name: an identifying name (unique!)
+  - name: a descriptive, identifying name (unique!)
   - children: embedded child purposes (optional)
 - node names are ignored, only the name attribute is used
             HEREDOC

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -337,34 +337,40 @@ module Rails
               class Purpose < ActiveYaml::Base
                 include ActiveHash::Associations
 
+                field :id
                 field :name
 
                 # a purpose can have many children_purposes (cf. purpose_tree)
-                has_many :children, class_name: 'Purpose'
+                has_many :children, class_name: "Purpose", foreign_key: "parent_id"
+                belongs_to :parent, class_name: "Purpose"
               end
             HEREDOC
           )
         end
 
-        File.open('app/models/purposes.yml', 'w') do |file|
+        File.open('purposes.yml', 'w') do |file|
           file.write(
             <<~HEREDOC
               ---
               # add your purpose tree here
-              purposes:
-                sales:
-                  id: 1
-                  name: sales
-                marketing:
-                  id: 2
-                  name: marketing
-                  children:
-                    email:
-                      id: 3
-                      name: email
-                    telephone:
-                      id: 4
-                      name: telephone
+              sales:
+                id: 1
+                name: sales
+              marketing:
+                id: 2
+                name: marketing
+              calls:
+                id: 3
+                name: sales_calls
+                parent_id: 1
+              email:
+                id: 4
+                name: email
+                parent_id: 2
+              telephone:
+                id: 5
+                name: telephone
+                parent_id: 2
             HEREDOC
           )
         end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -31,6 +31,9 @@ module Rails
         class_option :database,            type: :string, aliases: "-d", default: "sqlite3",
                                            desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 
+        class_option :purposeful,          type: :string, aliases: "-p", default: "true",
+                                           desc: "Make this app purposeful (options: true/false)."
+
         class_option :skip_yarn,           type: :boolean, default: false,
                                            desc: "Don't use Yarn for managing JavaScript dependencies"
 
@@ -137,6 +140,7 @@ module Rails
          jbuilder_gemfile_entry,
          psych_gemfile_entry,
          cable_gemfile_entry,
+         purpose_gemfile_entry,
          @extra_entries].flatten.find_all(&@gem_filter)
       end
 
@@ -195,6 +199,12 @@ module Rails
         return [] if options[:skip_puma]
         comment = "Use Puma as the app server"
         GemfileEntry.new("puma", "~> 3.11", comment)
+      end
+
+      def purpose_gemfile_entry # :doc:
+        return [] unless options[:purposeful] == 'true'
+        comment = "Use ActiveYaml for Purpose Storage"
+        GemfileEntry.new("active_hash", "~> 2.1", comment)
       end
 
       def include_all_railties? # :doc:

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -424,7 +424,7 @@ File.open('purposes.yml', 'w') { |f| f.write purposes.to_yaml }
 
         `ruby purpose_generator.rb`
 
-        File.open('PURPOSEFUL_README', 'w') do |file|
+        File.open('PURPOSEFUL_README.md', 'w') do |file|
           file.write(
             <<~HEREDOC
 # Purpose Generation

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -203,6 +203,8 @@ module Rails
 
       def purpose_gemfile_entry # :doc:
         return [] unless options[:purposeful] == 'true'
+
+        generate_purpose_model
         comment = "Use ActiveYaml for Purpose Storage"
         GemfileEntry.new("active_hash", "~> 2.1", comment)
       end
@@ -319,6 +321,52 @@ module Rails
         when "jdbcpostgresql" then ["activerecord-jdbcpostgresql-adapter", nil]
         when "jdbc"           then ["activerecord-jdbc-adapter", nil]
         else [options[:database], nil]
+        end
+      end
+
+      def generate_purpose_model
+        return unless options[:purposeful] == 'true'
+
+        `mkdir app`
+        `mkdir app/models`
+        `touch app/models/purpose.rb`
+
+        File.open('app/models/purpose.rb', 'w') do |file|
+          file.write(
+            <<~HEREDOC
+              class Purpose < ActiveYaml::Base
+                include ActiveHash::Associations
+
+                field :name
+
+                # a purpose can have many children_purposes (cf. purpose_tree)
+                has_many :children, class_name: 'Purpose'
+              end
+            HEREDOC
+          )
+        end
+
+        File.open('app/models/purposes.yml', 'w') do |file|
+          file.write(
+            <<~HEREDOC
+              ---
+              # add your purpose tree here
+              purposes:
+                sales:
+                  id: 1
+                  name: sales
+                marketing:
+                  id: 2
+                  name: marketing
+                  children:
+                    email:
+                      id: 3
+                      name: email
+                    telephone:
+                      id: 4
+                      name: telephone
+            HEREDOC
+          )
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -26,6 +26,9 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 # gem 'image_processing', '~> 1.2'
 <% end -%>
 
+# Use ActiveYaml for Purpose Storage
+gem 'active_hash'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -26,9 +26,6 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 # gem 'image_processing', '~> 1.2'
 <% end -%>
 
-# Use ActiveYaml for Purpose Storage
-gem 'active_hash'
-
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -23,6 +23,7 @@ DEFAULT_APP_FILES = %w(
   app/channels/application_cable/connection.rb
   app/controllers
   app/controllers/application_controller.rb
+  app/controllers/purposes_controller.rb
   app/controllers/concerns
   app/helpers
   app/helpers/application_helper.rb


### PR DESCRIPTION
- adds --purposeful flag for `rails new` (defaults to true)
- if app is --purposeful:
  - it adds active_hash to Gemfile
  - it creates a purpose model file
  - it creates a purposes.seed file with a demo purpose tree
  - it creates a purpose_generator.rb file to convert a purpose tree into a valid model yaml